### PR TITLE
Fix/217 Resolver problema na ação "mostrar" no cadastro de eventos

### DIFF
--- a/app/controllers/manager/events_controller.rb
+++ b/app/controllers/manager/events_controller.rb
@@ -10,7 +10,7 @@ class Manager::EventsController < ApplicationController
   end
 
   def show
-    @event = Event.includes(:prize_draw).find(params[:id])
+    @event = Event.includes(:prize_draw).friendly.find(params[:id])
   end
 
   def edit; end


### PR DESCRIPTION
Corrigido o problema na opção "mostrar" onde era exibido um cadastro diferente do que foi selecionado no cadastro de eventos. Para sanar o problema foi inserido o uso da gem friendly_id no método show em menager/events_controller.rb